### PR TITLE
add alias for :downloads

### DIFF
--- a/bin/selbot2.rb
+++ b/bin/selbot2.rb
@@ -61,7 +61,7 @@ Cinch::Bot.new {
       :help       => "links to downloads pages"
     },
     {
-      :expression => /:downloads/,
+      :expression => /:download(s|ing)/,
       :text       => "Please read this article about how to download files with Selenium, and why you shouldn't: http://ardesco.lazerycode.com/index.php/2012/07/how-to-download-files-with-selenium-and-why-you-shouldnt/",
       :help       => "links to article about downloading files"
     },


### PR DESCRIPTION
:downloads can be hard to remember, as it's pretty similar to :download.

typing `:downloads` or `:downloading` will now provide that link to why you shouldn't download via selenium