### PR TITLE
Ignore issue numbers from the Github bot.

### DIFF
--- a/lib/selbot2/issues.rb
+++ b/lib/selbot2/issues.rb
@@ -4,7 +4,7 @@ module Selbot2
 
     HELPS << ["#<issue-number>", "show issue"]
     HELPS << [":openissues", "show the number of open issues in the tracker"]
-    IGNORED_NICKS = %w[seljenkinsbot Selenium-Git]
+    IGNORED_NICKS = %w[seljenkinsbot Selenium-Github]
 
     listen_to :message
 

--- a/lib/selbot2/issues.rb
+++ b/lib/selbot2/issues.rb
@@ -4,7 +4,7 @@ module Selbot2
 
     HELPS << ["#<issue-number>", "show issue"]
     HELPS << [":openissues", "show the number of open issues in the tracker"]
-    IGNORED_NICKS = %w[seljenkinsbot Selenium-Github]
+    IGNORED_NICKS = %w[seljenkinsbot Selenium-Github selbot2-commits]
 
     listen_to :message
 


### PR DESCRIPTION
Every time the Selenium-Github bot posts about a new pull request,
selbot2 sees the issue number and posts a duplicate message about that
pull request.